### PR TITLE
Fix file listing and add ransomware antivirus example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,7 @@ Use `modules.tools.kill_process(pid)` in your antivirus script to terminate
 malicious simulations. The function also writes the `/tmp/block_ransom` flag so
 the backend recognizes that the process was blocked.
 
+Simulation and antivirus logs are stored in `backend/src/modules/summary/log.txt`.
+Look for lines beginning with `[RESULT]` to see whether each scenario was
+detected and blocked successfully.
+

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -8,6 +8,10 @@ from contextlib import redirect_stdout
 
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 TMP_DIR = os.path.join(BASE_DIR, "..", "tmp")
+SUMMARY_DIR = os.path.join(BASE_DIR, "modules", "summary")
+STATS_PATH = os.path.join(SUMMARY_DIR, "stats.json")
+LOG_PATH = os.path.join(SUMMARY_DIR, "log.txt")
+PROGRESS_PATH = os.path.join(SUMMARY_DIR, "progress.json")
 
 sys.path.append(BASE_DIR)
 from modules.decrypt import decrypt_files
@@ -32,7 +36,7 @@ def update_quiz_score():
     score = data.get("score")
     total = data.get("total")
 
-    path = os.path.join("modules", "summary", "stats.json")
+    path = STATS_PATH
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             stats = json.load(f)
@@ -128,7 +132,7 @@ def list_target_files():
             rel = os.path.relpath(os.path.join(root, name), TARGET_BASE)
             files.append("/target/" + rel.replace(os.path.sep, "/"))
 
-    files.extend(["/tmp/block_ransom", "/tmp/detection_result.txt"])
+    files.append("/tmp/detection_result.txt")
 
     return jsonify({"files": files})
 
@@ -156,7 +160,7 @@ def update_theory_progress():
     data = request.get_json()
     page = str(data.get("page"))
 
-    path = os.path.join("modules", "summary", "progress.json")
+    path = PROGRESS_PATH
     if os.path.exists(path):
         with open(path, "r", encoding="utf-8") as f:
             progress = json.load(f)
@@ -181,9 +185,9 @@ def generate_key():
 
 @app.route("/summary/logs", methods=["GET"])
 def get_logs():
-    log_path = os.path.join("modules", "summary", "log.txt")
-    progress_path = os.path.join("modules", "summary", "progress.json")
-    stats_path = os.path.join("modules", "summary", "stats.json")
+    log_path = LOG_PATH
+    progress_path = PROGRESS_PATH
+    stats_path = STATS_PATH
 
     # טען לוגים
     if os.path.exists(log_path):
@@ -358,7 +362,7 @@ def save_antivirus():
 
 @app.route("/summary/clear", methods=["POST"])
 def clear_summary_logs():
-    path = os.path.join("modules", "summary", "log.txt")
+    path = LOG_PATH
     try:
         open(path, "w").close()
         return jsonify({"status": "ok"})

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,5 +5,6 @@ These standalone Python scripts demonstrate simple antivirus behaviors for the p
 - `av_infection.py` – scans the sample `backend/tmp/TestInfected` directory for injected code and blocks the threat if found.
 - `av_encrypt.py` – checks files inside `backend/target` for the ransomware signature and blocks encryption attempts.
 - `av_decrypt.py` – decrypts files in `backend/target` that were previously encrypted with the provided key.
+- `av_ransom.py` – monitors `MALWARE_PID_FILE` and kills the running ransomware process if present.
 
 Each script writes detection to `/tmp/detection_result.txt` and calls `modules.tools.kill_process` to terminate the malicious process (which also creates `/tmp/block_ransom` for compatibility).

--- a/examples/av_ransom.py
+++ b/examples/av_ransom.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Standalone antivirus example for the ransomware simulation."""
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "backend", "src")))
+
+from modules.constants import MALWARE_PID_FILE
+from modules.tools import kill_process
+
+DETECTION_FILE = "/tmp/detection_result.txt"
+
+
+def scan_and_block():
+    if os.path.exists(MALWARE_PID_FILE):
+        try:
+            with open(MALWARE_PID_FILE) as f:
+                pid = int(f.read().strip() or "0")
+        except Exception:
+            pid = None
+        with open(DETECTION_FILE, "w") as d:
+            d.write("RANSOM")
+        kill_process(pid)
+        print("Ransomware process terminated.")
+    else:
+        print("No active ransomware detected.")
+
+
+if __name__ == "__main__":
+    scan_and_block()


### PR DESCRIPTION
## Summary
- document log file path for detecting simulation results
- provide `av_ransom.py` example antivirus
- update examples README with new script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68472b874fc88328a5428ac4583a8715