### PR TITLE
Fix file saving and clarify platform requirements

### DIFF
--- a/backend/src/modules/constants.py
+++ b/backend/src/modules/constants.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+# Base directory of the backend package
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
 TMP_DIR = tempfile.gettempdir()
 DETECTION_FILE = os.path.join(TMP_DIR, "detection_result.txt")

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -28,3 +28,24 @@ def test_list_target_files():
     assert 'files' in data
     assert isinstance(data['files'], list)
     assert len(data['files']) > 0
+
+
+def test_save_file_updates_contents():
+    client = app.test_client()
+
+    sample_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'target', 'sample.txt'))
+
+    with open(sample_path, 'r', encoding='utf-8') as f:
+        original = f.read()
+
+    try:
+        resp = client.post('/api/file', json={'path': '/target/sample.txt', 'content': 'modified'})
+        assert resp.status_code == 200
+        assert resp.get_json()['status'] == 'success'
+
+        with open(sample_path, 'r', encoding='utf-8') as f:
+            assert f.read() == 'modified'
+    finally:
+        with open(sample_path, 'w', encoding='utf-8') as f:
+            f.write(original)
+

--- a/backend/tests/test_simulation.py
+++ b/backend/tests/test_simulation.py
@@ -55,3 +55,24 @@ def test_simulate_decrypt_updates_stats(tmp_path):
 
     assert stats['task_results']['decrypt']['detected'] is True
     assert stats['task_results']['decrypt']['blocked'] is True
+
+
+def test_simulate_encrypt_changes_sample_file():
+    clear_flags()
+    client = app.test_client()
+
+    sample_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'target', 'sample.txt'))
+    with open(sample_path, 'rb') as f:
+        original = f.read()
+
+    try:
+        resp = client.post('/simulate', json={'task': 'encrypt'})
+        assert resp.status_code == 200
+
+        with open(sample_path, 'rb') as f:
+            assert f.read() != original
+    finally:
+        from modules.decrypt import decrypt_files
+        decrypt_files(os.path.dirname(sample_path))
+        with open(sample_path, 'wb') as f:
+            f.write(original)


### PR DESCRIPTION
## Summary
- document Linux focus and manual startup steps
- use OS temp directory for constants
- fix `/api/file` POST route and detection file handling
- update example antivirus scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472b874fc88328a5428ac4583a8715